### PR TITLE
add missing assertions from Fable.Mocha

### DIFF
--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Expecto" Version="9.*" />
     <PackageReference Include="Fable.Core" Version="3.1.5" />
-    <PackageReference Include="Fable.Mocha" Version="2.9.1" />
+    <PackageReference Include="Fable.Mocha" Version="2.10.0" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Update="FSharp.Core" Version="4.*" />

--- a/tests/Hedgehog.Tests/PropertyTests.fs
+++ b/tests/Hedgehog.Tests/PropertyTests.fs
@@ -14,4 +14,19 @@ let propertyTests = testList "Property tests" [
             |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
         Expect.isNotMatch report "\.\.\." "Abbreviation (...) found"
 
+    testCase "counterexample example" <| fun () ->
+        // based on examlpe from https://hedgehogqa.github.io/fsharp-hedgehog/index.html#Custom-Operations
+        let guid = System.Guid.NewGuid().ToString()
+        let tryAdd a b =
+            if a > 100 then None // Nasty bug.
+            else Some(a + b)
+        let report =
+            property {
+                let! a = Range.constantBounded () |> Gen.int
+                let! b = Range.constantBounded () |> Gen.int
+                counterexample guid
+                Some(a + b) =! tryAdd a b
+            }
+            |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
+        Expect.stringContains report guid "Missing counterexample text"
 ]

--- a/tests/Hedgehog.Tests/PropertyTests.fs
+++ b/tests/Hedgehog.Tests/PropertyTests.fs
@@ -1,11 +1,10 @@
 ﻿module Hedgehog.Tests.PropertyTests
 
 open Hedgehog
-open Expecto
 open TestDsl
 
 let propertyTests = testList "Property tests" [
-    fableIgnore "generated C# list of five elements is not abbreviated in the failure report" <| fun _ ->
+    testCase "generated C# list of five elements is not abbreviated in the failure report" <| fun _ ->
         let report =
             property {
                 let! xs = Range.singleton 0 |> Gen.int |> Gen.list (Range.singleton 5) |> Gen.map ResizeArray

--- a/tests/Hedgehog.Tests/TestDsl.fs
+++ b/tests/Hedgehog.Tests/TestDsl.fs
@@ -7,6 +7,9 @@ let testCase = Test.testCase
 let ptestCase = Test.ptestCase
 let testList = Test.testList
 
+module Tests =
+    let failtestf format = failwithf format
+
 #else
 open Expecto
 
@@ -22,6 +25,7 @@ let testCases (label : string) (xs : seq<'a>) (f : 'a -> unit) : List<TestCase> 
         testCase (sprintf "%s: (%A)" label x) (fun _ -> f x) ]
 
 let fableIgnore (label : string) (test : unit -> unit) : TestCase =
+
 #if FABLE_COMPILER
     // Some tests are not running in Node.js.
     ptestCase label test
@@ -34,5 +38,13 @@ let inline (=!) (actual : 'a) (expected : 'a) : unit =
 
 [<RequireQualifiedAccess>]
 module Expect =
+    open System.Text.RegularExpressions
+
     let isTrue value =
         Expect.isTrue value "Should be true"
+
+    let isNotMatch actual pattern message =
+        if Regex.Match(actual, pattern).Success then
+            Tests.failtestf "%s. Expected %s to match pattern: /%s/" message actual pattern
+
+    let stringContains = Expect.stringContains


### PR DESCRIPTION
added missing assertions `isNotMatch` & `stringsContains` to the TestDsl so the tests in `PropertyTests` are working in both .NET and in Fable/Javascript world.